### PR TITLE
Update readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ missing_docs = "warn"
 
 [lints.clippy]
 panic_in_result_fn = "warn"
-pedantic = "warn"
+# The explicit priority is required due to https://github.com/rust-lang/cargo/issues/13565.
+pedantic = { level = "warn", priority = -1 }
 unwrap_used = "warn"
 enum_variant_names = "allow"
 missing_errors_doc = "allow"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A serializer and deserializer for changelogs written in [Keep a Changelog](https
 ## Install
 
 ```sh
-cargo add keep_a_changelog
+cargo add --git https://github.com/heroku/keep_a_changelog
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cargo add --git https://github.com/heroku/keep_a_changelog
 ```rust
 use keep_a_changelog::{Changelog, ChangeGroup, PromoteOptions};
 
-fn main() {
+# fn main() {
     // parse a changelog
     let mut changelog: Changelog = "\
 # Changelog
@@ -51,5 +51,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     // output the changelog
     println!("{}", changelog);
-}
+# }
 ```

--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
 # Keep a Changelog Serializer/Deserializer
 
-[![Build Status]][ci] [![Docs]][docs.rs] [![Latest Version]][crates.io] [![MSRV]][install-rust]
+[![Build Status]][ci] [![MSRV]][install-rust]
 
 [Build Status]: https://img.shields.io/github/actions/workflow/status/colincasey/keep_a_changelog/ci.yml?branch=main
 [ci]: https://github.com/colincasey/keep_a_changelog/actions/workflows/ci.yml?query=branch%3Amain
-[Docs]: https://img.shields.io/docsrs/keep_a_changelog
-[docs.rs]: https://docs.rs/keep_a_changelog/latest/keep_a_changelog/
-[Latest Version]: https://img.shields.io/crates/v/keep_a_changelog.svg
-[crates.io]: https://crates.io/crates/keep_a_changelog
 [MSRV]: https://img.shields.io/badge/MSRV-rustc_1.74+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ cargo add --git https://github.com/heroku/keep_a_changelog
 ```rust
 use keep_a_changelog::{Changelog, ChangeGroup, PromoteOptions};
 
-# fn main() {
-    // parse a changelog
-    let mut changelog: Changelog = "\
+// parse a changelog
+let mut changelog: Changelog = "\
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -31,25 +30,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]"
-        .parse()
-        .unwrap();
-    
-    // modify the unreleased section
-    changelog.unreleased.add(
-        ChangeGroup::Fixed, 
-        "Fixed bug in feature X"
-    );
-    changelog.unreleased.add(
-        ChangeGroup::Deprecated, 
-        "Feature Y will be removed from the next major release"
-    );
-    
-    // promote the unreleased changes to a new release
-    let promote_options = PromoteOptions::new("0.0.1".parse().unwrap())
-        .with_link("https://github.com/my-org/my-project/releases/v0.0.1".parse().unwrap());
-    changelog.promote_unreleased(&promote_options).unwrap();
+    .parse()
+    .unwrap();
 
-    // output the changelog
-    println!("{}", changelog);
-# }
+// modify the unreleased section
+changelog.unreleased.add(
+    ChangeGroup::Fixed, 
+    "Fixed bug in feature X"
+);
+changelog.unreleased.add(
+    ChangeGroup::Deprecated, 
+    "Feature Y will be removed from the next major release"
+);
+
+// promote the unreleased changes to a new release
+let promote_options = PromoteOptions::new("0.0.1".parse().unwrap())
+    .with_link("https://github.com/my-org/my-project/releases/v0.0.1".parse().unwrap());
+changelog.promote_unreleased(&promote_options).unwrap();
+
+// output the changelog
+println!("{}", changelog);
 ```

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status]][ci] [![MSRV]][install-rust]
 
-[Build Status]: https://img.shields.io/github/actions/workflow/status/colincasey/keep_a_changelog/ci.yml?branch=main
-[ci]: https://github.com/colincasey/keep_a_changelog/actions/workflows/ci.yml?query=branch%3Amain
+[Build Status]: https://img.shields.io/github/actions/workflow/status/heroku/keep_a_changelog/ci.yml?branch=main
+[ci]: https://github.com/heroku/keep_a_changelog/actions/workflows/ci.yml?query=branch%3Amain
 [MSRV]: https://img.shields.io/badge/MSRV-rustc_1.74+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install
 


### PR DESCRIPTION
This PR removes broken crates.io and docs.rs links, and updates GitHub CI references (following repository migration to heroku org) as well as installation instructions.