### PR TITLE
Rename to `keep_a_changelog_file` to avoid crate conflict

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -6,3 +6,4 @@
 # Datasource local storage ignored files
 /dataSources/
 /dataSources.local.xml
+/jsLibraryMappings.xml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,18 @@
 [package]
-name = "keep_a_changelog"
+name = "keep_a_changelog_file"
 version = "0.1.0"
+description = "Read and write changelog files using the Keep a Changelog format"
+repository = "https://github.com/heroku/keep_a_changelog"
+license = "Apache-2.0"
+keywords = ["keep-a-changelog", "changelog", "serialize", "deserialize"]
+categories = ["parser-implementations", "parsing"]
 edition = "2021"
 rust-version = "1.74"
+exclude = [
+    ".idea",
+    ".github",
+    ".editorconfig"
+]
 
 [dependencies]
 chrono = "0.4"

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ cargo add keep_a_changelog_file
 ## Usage
 
 ```rust
-use keep_a_changelog_file::{Changelog, ChangeGroup, PromoteOptions};
+use keep_a_changelog_file::{Changelog, ChangeGroup, PromoteOptions, ReleaseLink, ReleaseVersion};
 
-// parse a changelog
-let mut changelog: Changelog = "\
+fn example_usage() {
+    // parse a changelog
+    let mut changelog: Changelog = "\
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -26,25 +27,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]"
-.parse() ?;
+        .parse()
+        .unwrap();
 
-// modify the unreleased section
-changelog.unreleased.add(
-ChangeGroup::Fixed,
-"Fixed bug in feature X"
-);
-changelog.unreleased.add(
-ChangeGroup::Deprecated,
-"Feature Y will be removed from the next major release"
-);
+    // modify the unreleased section
+    changelog
+        .unreleased
+        .add(ChangeGroup::Fixed, "Fixed bug in feature X");
+    changelog.unreleased.add(
+        ChangeGroup::Deprecated,
+        "Feature Y will be removed from the next major release",
+    );
 
-// promote the unreleased changes to a new release
-let promote_options = PromoteOptions::new("0.0.1".parse() ? )
-.with_link("https://github.com/my-org/my-project/releases/v0.0.1".parse() ? );
-changelog.promote_unreleased( & promote_options) ?;
+    // promote the unreleased changes to a new release
+    let release_version = "0.0.1".parse::<ReleaseVersion>().unwrap();
+    let release_link = "https://github.com/my-org/my-project/releases/v0.0.1"
+        .parse::<ReleaseLink>()
+        .unwrap();
+    changelog
+        .promote_unreleased(&PromoteOptions::new(release_version).with_link(release_link))
+        .unwrap();
 
-// output the changelog
-println!("{}", changelog);
+    // output the changelog
+    println!("{changelog}");
+}
 ```
 
 [Build Status]: https://img.shields.io/github/actions/workflow/status/heroku/keep_a_changelog/ci.yml?branch=main

--- a/README.md
+++ b/README.md
@@ -1,24 +1,20 @@
-# Keep a Changelog Serializer/Deserializer
+# Keep a Changelog File
 
 [![Build Status]][ci] [![MSRV]][install-rust]
 
-[Build Status]: https://img.shields.io/github/actions/workflow/status/heroku/keep_a_changelog/ci.yml?branch=main
-[ci]: https://github.com/heroku/keep_a_changelog/actions/workflows/ci.yml?query=branch%3Amain
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.74+-lightgray.svg
-[install-rust]: https://www.rust-lang.org/tools/install
-
-A serializer and deserializer for changelogs written in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+A serializer and deserializer for changelog files written in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+format.
 
 ## Install
 
 ```sh
-cargo add --git https://github.com/heroku/keep_a_changelog
+cargo add keep_a_changelog_file
 ```
 
 ## Usage
 
 ```rust
-use keep_a_changelog::{Changelog, ChangeGroup, PromoteOptions};
+use keep_a_changelog_file::{Changelog, ChangeGroup, PromoteOptions};
 
 // parse a changelog
 let mut changelog: Changelog = "\
@@ -30,24 +26,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]"
-    .parse()
-    .unwrap();
+.parse() ?;
 
 // modify the unreleased section
 changelog.unreleased.add(
-    ChangeGroup::Fixed, 
-    "Fixed bug in feature X"
+ChangeGroup::Fixed,
+"Fixed bug in feature X"
 );
 changelog.unreleased.add(
-    ChangeGroup::Deprecated, 
-    "Feature Y will be removed from the next major release"
+ChangeGroup::Deprecated,
+"Feature Y will be removed from the next major release"
 );
 
 // promote the unreleased changes to a new release
-let promote_options = PromoteOptions::new("0.0.1".parse().unwrap())
-    .with_link("https://github.com/my-org/my-project/releases/v0.0.1".parse().unwrap());
-changelog.promote_unreleased(&promote_options).unwrap();
+let promote_options = PromoteOptions::new("0.0.1".parse() ? )
+.with_link("https://github.com/my-org/my-project/releases/v0.0.1".parse() ? );
+changelog.promote_unreleased( & promote_options) ?;
 
 // output the changelog
 println!("{}", changelog);
 ```
+
+[Build Status]: https://img.shields.io/github/actions/workflow/status/heroku/keep_a_changelog/ci.yml?branch=main
+
+[ci]: https://github.com/heroku/keep_a_changelog/actions/workflows/ci.yml?query=branch%3Amain
+
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.74+-lightgray.svg
+
+[install-rust]: https://www.rust-lang.org/tools/install
+
+[Docs]: https://img.shields.io/docsrs/keep_a_changelog_file
+
+[docs.rs]: https://docs.rs/keep_a_changelog/latest/keep_a_changelog_file/
+
+[Latest Version]: https://img.shields.io/crates/v/keep_a_changelog_file.svg
+
+[crates.io]: https://crates.io/crates/keep_a_changelog_file

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used)]
 #![allow(unused_crate_dependencies)]
 
-use keep_a_changelog::{ChangeGroup, Changelog, PromoteOptions};
+use keep_a_changelog_file::{ChangeGroup, Changelog, PromoteOptions};
 
 #[test]
 fn adding_unreleased_changes() {


### PR DESCRIPTION
This is a follow up to #6. The library has been renamed to `keep_a_changelog_file` to avoid a conflict with an existing crate.